### PR TITLE
Correct option parsing

### DIFF
--- a/prctl.c
+++ b/prctl.c
@@ -297,8 +297,8 @@ main(int argc, char **argv)
 		exit(1);
 	}
 	opterr = 0;
-	while ((opt = getopt_long(argc, argv, "+qhv", longopts, 
-					(int *) NULL)) != EOF) {
+	while ((opt = getopt_long(argc, argv, "+qhv", longopts,
+					(int *) NULL)) != -1) {
 		switch (opt) {
 		case 'u':
 			if (strcmp(optarg, "silent") == 0) {

--- a/prctl.c
+++ b/prctl.c
@@ -373,8 +373,8 @@ main(int argc, char **argv)
 			break;
 
 		case '?':
-			fprintf(stderr, "%s: invalid option - %c\n", 
-					progname, optopt);
+			fprintf(stderr, "%s: invalid option: %s\n",
+					progname, argv[optind - 1]);
 			exit(1);
 			break;
 		}


### PR DESCRIPTION
This PR suggests two minor corrections to option parsing:

1. When passed an invalid long option, the programme would display nothing instead of the invalid option (`optopt` being `0`), and
2. `getopt_long()` returns `-1` after the last option argument according to its man page, and while `EOF` is typically defined as `-1` (at least by glibc and musl), it is not guaranteed to be.